### PR TITLE
Add Toys section with Qubi

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Quantum computing leverages the principles of quantum mechanics to process infor
 - [APIs & SDKs](#apis--sdks)
 - [Quantum Algorithms](#quantum-algorithms)
 - [Quantum Programming Languages](#quantum-programming-languages)
+- [Toys](#toys)
 - [Communities & Organizations](#communities--organizations)
 - [Papers & Research](#papers--research)
 - [Related Awesome Lists](#related-awesome-lists)
@@ -89,6 +90,10 @@ Quantum computing leverages the principles of quantum mechanics to process infor
 - [Silq](https://silq.ethz.ch/) – High-level quantum language from ETH Zurich.
 - [Quil](https://pyquil-docs.rigetti.com/en/stable/) – Quantum Instruction Language by Rigetti.
 - [OpenQASM](https://github.com/Qiskit/openqasm) – Intermediate representation for quantum circuits (IBM).
+
+## Toys
+
+- [Qubi](https://www.qolour.io) – A physical model qubit. Two entangled spheres you rotate, measure, and entangle by hand, with a companion app that runs circuits on real IBM and IonQ hardware.
 
 ## Communities & Organizations
 


### PR DESCRIPTION
Adding a new "Toys" section with one entry: Qubi, a physical model qubit — two entangled spheres you rotate, measure, and entangle by hand, with a companion app that runs circuits on real IBM and IonQ hardware.

The existing categories (Libraries, Simulators, Hardware Providers, SDKs) all assume software or cloud access, so a hands-on physical device doesn't have a clean home. A "Toys" section gives it one and leaves room for future additions (e.g. Entanglion, QiskitBlocks) without stretching an existing category.

Entry follows the list's `[Name](URL) – Description.` format.

Disclosure: I work on Qubi.
